### PR TITLE
Dockerize the backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
-MONGO_URI="mongodb://localhost:27017/myapp"
+MONGO_URI="mongodb://mongodb:27017/myapp"
 PORT=2041

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,0 @@
-FROM node:16.9.1
-WORKDIR /app
-COPY package.json .
-RUN npm install
-COPY . ./
-EXPOSE 3000
-CMD [ "npm", "run", "pm2" ]

--- a/README.md
+++ b/README.md
@@ -62,9 +62,16 @@ git checkout your-branch-name
 
 To run the development server, do the following in the `arc-backend` directory:
 
+##Non-Docker Version
 ```bash
 $ npm install
 $ npm run dev
+```
+
+##Docker Version
+
+```bash
+$ npm run install && npm dockerize
 ```
 
 You can now see the project running on your localhost

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:16.9.1
+WORKDIR /app
+COPY .. ./
+COPY .env.example .env
+RUN npm install
+RUN npm install -g nodemon
+EXPOSE 3000
+CMD [ "nodemon" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,6 @@ FROM node:16.9.1
 WORKDIR /app
 COPY .. ./
 COPY .env.example .env
-RUN npm install
 RUN npm install -g nodemon
 EXPOSE 3000
 CMD [ "nodemon" ]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.9'
+
+services:
+  arc-backend:
+    build:
+      context: ../
+      dockerfile: ./docker/Dockerfile
+    depends_on:
+      - mongodb
+    volumes:
+      - '../:/app'
+    ports:
+      - 3000:3000
+    environment:
+      - CHOKIDAR_USEPOLLING=true
+  mongodb:
+    image: mongo:latest
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: root
+    ports:
+      - "27017:27017"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "start": "cross-env NODE_ENV=production node app.js",
     "dev": "nodemon",
-    "test": "jest"
+    "test": "jest",
+    "docker-build": "docker-compose -f docker/docker-compose.yml build",
+    "dockerize": "npm run docker-build && npm run docker-start",
+    "docker-start": "docker-compose -f docker/docker-compose.yml  up -d"
   },
   "dependencies": {
     "body-parser": "^1.19.0",


### PR DESCRIPTION
Hi,
I took the freedom and dockerized the backend application.

Now you can just quickstart the application and use the new command to dockerize it and work locally without installing mongodb locally.
The MongoDB is currently **not** persisted, that could be an improvement for local development.

The README was also adjusted :-) Hope it is helpful to get people started quickly!
